### PR TITLE
Pull display names for youtube and Mixer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A Python script for use in [Streamlabs Chatbots's](https://streamlabs.com/chatbot) built-in scripting feature which announces in chat when a user changes ranks.
 You can check out the functionality on [Github](https://github.com/HyperNeon/ankhbot-rank-change-announcer)
 
-This script will monitor all Twitch users currently connected to chat and make an announcement in Twitch chat whenever a user ranks up or ranks down. The script allows you to customize:
+This script will monitor all Twitch/YouTube/Mixer users currently connected to chat and make an announcement in chat whenever a user ranks up or ranks down. The script allows you to customize:
 * The message sent when a user ranks up
 * The message sent when a user ranks down
 * How often the script should run

--- a/RankChangeAnnouncer_StreamlabsSystem.py
+++ b/RankChangeAnnouncer_StreamlabsSystem.py
@@ -12,7 +12,7 @@ import time
 ScriptName = "Rank Change Announcer"
 Website = "https://www.github.com/hyperneon"
 Creator = "GameTangent"
-Version = "1.2.0"
+Version = "1.3.0"
 Description = "Announce in chat when a user changes ranks"
 
 #---------------------------------------
@@ -73,10 +73,15 @@ def GetRankList():
         
     ranks = BuildRankHash(viewers)
     points = Parent.GetPointsAll(viewers)
+    names = Parent.GetDisplayNames(viewers)
     
     rank_list = {}   
-    for name,rank in ranks.items():
-        rank_list[name] = {'rank': rank, 'points': points[name]}
+    for id,name in names.items():
+        try:
+            rank_list[name] = {'rank': ranks[id], 'points': points[id]}
+        except:
+            Parent.Log(ScriptName, "Failed to get Rank or Points for User: " + name + "  Please check if the user exists in the Users tab")
+            continue
     
     return rank_list
     

--- a/UI_Config.json
+++ b/UI_Config.json
@@ -25,7 +25,7 @@
 		"type": "checkbox",
 		"value": false,
 		"label": "Use Streamlabs Extension Currency",
-		"tooltip": "Check this if you are using the Streamlabs Extension Currency for the rest of the bot.\r\nNOTE: This is a temporary fix and will negatively impact performance.\r\nStreamers with a lot of concurrent viewers should increase the announcer timer if using this feature",
+		"tooltip": "[TWITCH ONLY] Check this if you are using the Streamlabs Extension Currency for the rest of the bot.\r\nNOTE: This is a temporary fix and will negatively impact performance.\r\nStreamers with a lot of concurrent viewers should increase the announcer timer if using this feature",
 		"group": "Announcer Settings"
 	},
 	"rank_system": {


### PR DESCRIPTION
Updated script to pull display names for users. Also added try/except/continue block for occasions where users are being retrieved in viewer list but haven't been added to user/rank/points lists yet. 